### PR TITLE
Fix gem build by using using new license file name

### DIFF
--- a/koalagator.gemspec
+++ b/koalagator.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = [">= 2.6.0"]
 
-  s.files = Dir["{app,config,lib,vendor}/**/*"] + Dir["db/**/*.rb"] + ["MIT-LICENSE.txt", "Rakefile", "README.md", "rails_template.rb"]
+  s.files = Dir["{app,config,lib,vendor}/**/*"] + Dir["db/**/*.rb"] + ["LICENSE.md", "Rakefile", "README.md", "rails_template.rb"]
   s.executables << "koalagator"
 
   # To change this Rails requirement, update RAILS_VERSION in lib/calagator/version.rb


### PR DESCRIPTION
gem build broke because one of the bundled files was renamed