### PR TITLE
Fix code scanning alert no. 57: Client-side cross-site scripting

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -17,8 +17,10 @@
       <img src="/assets/confused-alligator-sm.png" />
     </div>
     <p class="guide">Confused Alligator will look into the problem and try to clear up the confusion soon.</p>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.3.4/purify.min.js"></script>
     <script>
-      document.write('<a href="' + document.referrer + '">Back to Safety</a>');
+      var safeReferrer = DOMPurify.sanitize(document.referrer);
+      document.write('<a href="' + safeReferrer + '">Back to Safety</a>');
     </script>
   </div>
 </body>


### PR DESCRIPTION
Fixes [https://github.com/koalagator/koalagator/security/code-scanning/57](https://github.com/koalagator/koalagator/security/code-scanning/57)

To fix the problem, we need to ensure that the `document.referrer` value is properly sanitized or encoded before being used in the `document.write` method. The best way to fix this issue is to use a library like `DOMPurify` to sanitize the input, ensuring that any potentially harmful scripts are removed.

1. Include the `DOMPurify` library in the HTML file.
2. Use `DOMPurify` to sanitize the `document.referrer` value before writing it to the document.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
