### PR TITLE
Tabular events view

### DIFF
--- a/app/controllers/calagator/events_controller.rb
+++ b/app/controllers/calagator/events_controller.rb
@@ -24,6 +24,15 @@ module Calagator
       render_events @events
     end
 
+    # GET /events/tabular
+    # GET /events/tabular.xml
+    def tabular
+      @browse = Event::Browse.new(params)
+      @events = @browse.events
+      @browse.errors.each { |error| append_flash :failure, error }
+      render_events @events
+    end
+
     # GET /events/1
     # GET /events/1.xml
     def show

--- a/app/views/calagator/admin/index.html.erb
+++ b/app/views/calagator/admin/index.html.erb
@@ -9,5 +9,6 @@
     <li><%= link_to "Manage users", admin_users_path %></li>
   <% end %>
   <li><%= link_to "Manage curations", admin_curations_path %></li>
+  <li><%= link_to "Tablular Events View", '/events/tabular' %></li>
   <li><%= link_to "Bulk Import from CSV File", new_admin_bulk_import_path %></li>
 </ul>

--- a/app/views/calagator/events/_table.html.erb
+++ b/app/views/calagator/events/_table.html.erb
@@ -34,16 +34,16 @@ rowspans = calculate_rowspans(events)
       <% events.each_with_index do |event, index| %>
         <tr class='vevent h-event'>
           <% if rowspans[index] > 0 %>
-          <td class='date' rowspan="<%=rowspans[index]%>">
-            <div class='day_of_week <%= today_tomorrow_or_weekday(event).downcase -%>'>
-              <%= today_tomorrow_or_weekday(event) %>
-            </div>
-            <% show_year = event.start_time.year != Time.now.year %>
-            <%= datetime_format(event.start_time,'%b %d') -%><%= ", "+datetime_format(event.start_time,'%Y') if show_year %>
-          </td>
+            <td class='date' rowspan="<%=rowspans[index]%>">
+              <div class='day_of_week <%= today_tomorrow_or_weekday(event).downcase -%>'>
+                <%= today_tomorrow_or_weekday(event) %>
+              </div>
+              <% show_year = event.start_time.year != Time.now.year %>
+              <%= datetime_format(event.start_time,'%b %d') -%><%= ", "+datetime_format(event.start_time,'%Y') if show_year %>
+            </td>
           <% end %>
           <td class='event_summary'>
-            <%= link_to event.title, event_url, class: "summary p-name u-url #{'orange' if event.created_at.to_date == Date.today}",  
+            <%= link_to event.title, event, class: "summary p-name u-url #{'orange' if event.created_at.to_date == Date.today}",
                 id: "event-#{event.id}",
                 name: "event-#{event.id}",
                 title: "Added #{event.created_at}"

--- a/app/views/calagator/events/_table.html.erb
+++ b/app/views/calagator/events/_table.html.erb
@@ -43,7 +43,11 @@ rowspans = calculate_rowspans(events)
           </td>
           <% end %>
           <td class='event_summary'>
-            <a class='summary p-name u-url <%= "orange" if event.created_at.to_date == Date.today %>' href='<%= url_for event_url(event) %>' name='<%= "event-#{event.id}" %>' id='<%= "event-#{event.id}" %>' title="Added <%= event.created_at %>"><%= event.title %></a><br/>
+            <%= link_to event.title, event_url, class: "summary p-name u-url #{'orange' if event.created_at.to_date == Date.today}",  
+                id: "event-#{event.id}",
+                name: "event-#{event.id}",
+                title: "Added #{event.created_at}"
+            %>
             <%= normalize_time(event, :context => event.start_time.to_date) -%>
             <% if event.venue && !event.venue.title.blank? %>
               <a class='location p-location h-card' href='<%= url_for venue_url(event.venue) %>'><%= event.venue.title -%></a>

--- a/app/views/calagator/events/_tabular.html.erb
+++ b/app/views/calagator/events/_tabular.html.erb
@@ -1,0 +1,59 @@
+<% links ||= {} %>
+<div class='list_description'>
+  <h2>Viewing <strong><%= browse.events.size %></strong>
+  <%= browse.date ? 'filtered' : 'future' %> events
+  <%= events_sort_label(browse.order) %></h2>
+</div>
+
+<div id='list_filters' class='sidebar'>
+
+  <h3 class='first'>Filter:</h3>
+
+  <%= form_tag events_url, :method => 'get' do  -%>
+
+  <div id="date_filter">
+    <h4>by date</h4>
+    <div id='start_calendar'>
+      <label for='date_start'>From</label>
+      <%= text_field_tag 'date[start]', browse.start_date, :id => 'date_start', :class => 'date_picker' %>
+    </div>
+    <div id='end_calendar'>
+      <label for='date_end'>To</label>
+      <%= text_field_tag 'date[end]', browse.end_date, :id => 'date_end', :class => 'date_picker' %>
+    </div>
+  </div>
+  <div id='time_filter'>
+  <h4>by time</h4>
+    <div id='start_time_picker'>
+      <label for="time_start">Begins after:</label>
+      <%= text_field_tag 'time[start]', browse.start_time, :id => 'filter_time_start', :class => 'time_picker_filter' %>
+    </div>
+    <div id='end_time_picker'>
+      <label for="time_end">Ends before:</label>
+      <%= text_field_tag 'time[end]', browse.end_time, :id => 'filter_time_end', :class => 'time_picker_filter' %>
+    </div>
+  </div>
+  <div>
+    <label for="commit">&nbsp;</label>
+    <%= submit_tag 'Filter' %>
+    <span class="clear_filter"><%= link_to 'Reset', events_url %></span>
+  </div>
+  <% end %>
+
+  <h3>Subscribe to</h3>
+  <ul>
+    <li><%= link_to "iCalendar feed", links[:ical] %></li>
+    <li><%= link_to "Atom feed", links[:atom] %></li>
+    <li><%= link_to "Google Calendar", links[:google] %></li>
+  </ul>
+
+  <h3>Export to</h3>
+  <ul>
+    <li><%= link_to "iCalendar file", links[:ical_export] %></li>
+  </ul>
+
+</div>
+
+<div class='list_items'>
+  <%= render :partial => 'calagator/events/tabular_table', :locals => { :events => browse.events } %>
+</div>

--- a/app/views/calagator/events/_tabular_table.html.erb
+++ b/app/views/calagator/events/_tabular_table.html.erb
@@ -1,0 +1,78 @@
+<%-
+# Arguments:
+# * events => Array of Event records.
+# * scores => Offer a sort by score, like for search? Default to false.
+
+scores = defined?(scores) ? scores : false
+
+previous_start_time = nil
+#show_year ||= false
+skipped = 0
+
+# calculate rowspans array for events
+# each entry is number of rows spanned by today_tomorrow_weekday entry, if any, to left of event
+# entry will be > 0 for first event of day, 0 for other events
+rowspans = calculate_rowspans(events)
+-%>
+<table class='event_table'>
+  <thead>
+    <tr>
+      <th class='date'>Sort By: <%= link_to "Date", url_for(params.to_unsafe_h.merge(:order => 'date')) %></th>
+      <th class='event_summary'>
+        <%= events_sort_link('name') -%>,
+        <%= events_sort_link('venue') -%>,
+        <%= events_sort_link('created_at') -%>
+        <%- if scores -%>,
+        <%= events_sort_link('score') -%>
+        <%- end -%>, 
+        <%= events_sort_link(nil) -%>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% unless events.size==0 %>
+      <% events.each_with_index do |event, index| %>
+        <tr class='vevent h-event'>
+          <% if rowspans[index] > 0 %>
+            <td class='event_title rowspan="<%=rowspans[index]%>"'>
+              <%= link_to event.title, (event.url || event_url(event)), 
+                class: "summary p-name u-url #{'orange' if event.created_at.to_date == Date.today}",  
+                id: "event-#{event.id}",
+                name: "event-#{event.id}",
+                title: "Added #{event.created_at}"
+              %>
+              <br/>
+            </td>
+            <td class='event_date'>
+              <div class='day_of_week <%= today_tomorrow_or_weekday(event).downcase -%>'>
+                <%= today_tomorrow_or_weekday(event) %>
+                <% show_year = event.start_time.year != Time.now.year %>
+                <%= datetime_format(event.start_time,'%b %d') -%><%= ", "+datetime_format(event.start_time,'%Y') if show_year %>
+              </div>
+              <%= normalize_time(event, :context => event.start_time.to_date) -%>
+            </td>
+          <% end %>
+          <td class='event_location'>
+            <% if event.venue && !event.venue.title.blank? %>
+              <a class='location p-location h-card' href='<%= url_for venue_url(event.venue) %>'><%= event.venue.title %></a>
+            <% end -%>
+          </td>  
+          <td class='event_summary'>
+            <%= format_description(event.description) %>    
+          </td>
+        </tr>
+      <% end %>
+    <% else %>
+      <tr>
+        <td colspan=2>No events were found.</td>
+      </tr>
+    <% end %>
+    <% if skipped > 0 %>
+      <tr>
+        <td colspan=2>
+          <%= link_to "(And #{skipped} more)", events_url %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/calagator/events/tabular.html.erb
+++ b/app/views/calagator/events/tabular.html.erb
@@ -1,0 +1,12 @@
+<h1>Tabular Events</h1>
+<%= content_for :title, "Events" %>
+
+<% cache_if(@browse.default? && Calagator.cache_enabled, Calagator::CacheObserver.daily_key_for("events_index", request)) do %>
+<%= render partial: "tabular", locals: {browse: @browse, links: {
+    ical: icalendar_feed_link,
+    atom: atom_feed_link,
+    google: google_events_subscription_link,
+    ical_export: icalendar_export_link
+  }}
+%>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,11 +47,11 @@ Calagator::Engine.routes.draw do
 
   resources :events do
     collection do
-      get "tabular" => "events#tabular"
       post :squash_many_duplicates
       get :search
       get :duplicates
       get "tag/:tag", action: :search, as: :tag
+      get "tabular" => "events#tabular"
     end
 
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Calagator::Engine.routes.draw do
 
   resources :events do
     collection do
+      get "tabular" => "events#tabular"
       post :squash_many_duplicates
       get :search
       get :duplicates

--- a/spec/features/import_events_from_feed_spec.rb
+++ b/spec/features/import_events_from_feed_spec.rb
@@ -30,7 +30,8 @@ describe "import events from a feed", js: true do
     FLASH
 
     expect(page).to have_content "Viewing 3 future events"
-
-    expect(find(".event_table")).to have_content(/Coffee\swith\sJason\n.*\nCoffee\swith\sMike\n.*\nCoffee\swith\sKim/)
+    expect(find(".event_table")).to have_content(/Coffee\swith\sJason/)
+    expect(find(".event_table")).to have_content(/Coffee\swith\sMike/)
+    expect(find(".event_table")).to have_content(/Coffee\swith\sKim/)
   end
 end


### PR DESCRIPTION
This view has been added to support a local newsletter that wants to publish events out to their print publication.
The new view features:
- Revised layout that supports four clear columns (title, date time, venue, details).
- Unlike other views that link event titles within the instance, on this page the title is a link that goes to the related event url if present or falls back to linking to the event record in the instance otherwise. This is what is desired for external copy paste of the event records.

The page is unauthenticated and available to be accessed by anyone, but its considered a hidden feature for everyday users (it not needed by regular site visitors and with the link change doesnt conform to usual linking expectations in the site. The view has been added to the Admin Tools menu to aid discoverability by Mods and Admins).