### PR TITLE
Update Bundler from 2.6.6 to 2.6.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -560,4 +560,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.6.6
+   2.6.9


### PR DESCRIPTION
This small PR updates the bundler version in the Gemfile.lock from 2.6.6 to 2.6.9.